### PR TITLE
Task: pluggable token storage + robust state handling across OIDC flows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ phpstan.neon
 testbench.yaml
 /docs
 /coverage
+
+WARP.md
+.junie
+docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,26 @@ Fixed: update JWKS endpoint to use GET method instead of POST
 
 ### 0.0.6 - 2025-03-03
 - Added support for Laravel 12
+
+### 1.0.0 - 2025-09-01
+
+Added
+- Pluggable token storage abstraction with TokenStorageContract and implementations for session, cache (with optional TTL), and stateless (none).
+- Service container binding for TokenStorageContract to resolve the appropriate storage driver based on configuration.
+- Configuration options to control storage (openid-connect.storage), session key prefix, cache store, and cache TTL.
+- State bundle persistence keyed by state (nonce and optional code_verifier) to support robust state validation across flows.
+- New tests: Base64Helper encoding/decoding, OpenIDConnectManager JWT claims verification, and TokenManager state bundle lifecycle.
+
+Changed
+- TokenManager refactored to use the pluggable storage layer; commitSession now delegates to the storage backend.
+- Authorization Code and Implicit flows now load nonce/code_verifier from a state-scoped bundle and aggressively clear transient secrets (nonce, code_verifier, bundle) after use.
+- PKCE handling improved: generate S256/plain challenges when the provider advertises support; always clear code_verifier after a token request attempt.
+- Configuration file updated with storage-related options and defaults.
+
+Security
+- Hardened state and nonce handling; clearer exceptions around invalid/missing state, redirect URL, client ID, scope, and JWT processing.
+
+BREAKING CHANGE
+- Session key names are normalised (nonce/state/code_verifier) and managed through a pluggable storage layer
+- getClientID/getClientSecret are now non-nullable
+- Base64Helper::base64urlDecode signature now returns string

--- a/config/openid-connect.php
+++ b/config/openid-connect.php
@@ -9,6 +9,17 @@ declare(strict_types=1);
  */
 
 return [
+    // Storage configuration for OIDC transient values (state, nonce, code_verifier)
+    // Options: 'session' (default), 'cache', 'none' (stateless)
+    'storage' => env('OPENID_CONNECT_STORAGE', 'session'),
+
+    // Prefix applied to keys when storing in session or cache
+    'session_key_prefix' => env('OPENID_CONNECT_KEY_PREFIX', 'openid_connect_'),
+
+    // When storage = cache, you can specify cache store and TTL
+    // null TTL means store forever
+    'cache_store' => env('OPENID_CONNECT_CACHE_STORE', ''),
+    'cache_ttl' => env('OPENID_CONNECT_CACHE_TTL', 300),
     /** The default authentication provider to be used. if a provider is not specified */
     'default_provider' => env('OPENID_CONNECT_DEFAULT_PROVIDER', ''),
     /** The default redirect URL to be used. if a provider redirect url is not provided. */

--- a/src/Contracts/TokenStorageContract.php
+++ b/src/Contracts/TokenStorageContract.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CreativeCrafts\LaravelOpenidConnect\Contracts;
+
+interface TokenStorageContract
+{
+    public function put(string $key, string $value): void;
+
+    public function get(string $key): ?string;
+
+    public function forget(string $key): void;
+
+    public function commit(): void;
+}

--- a/src/Helpers/Base64Helper.php
+++ b/src/Helpers/Base64Helper.php
@@ -12,10 +12,11 @@ final class Base64Helper implements Base64HelperContract
      * Decodes a base64url encoded string to its original form.
      *
      * @param string $base64url The base64url encoded string to decode.
-     * @return bool|string Returns the decoded string on success, or false on failure.
+     * @return string Returns the decoded string.
      */
-    public static function base64urlDecode(string $base64url): bool|string
+    public static function base64urlDecode(string $base64url): string
     {
+        // base64_decode may return false on failure, but our inputs are controlled; cast to string
         return base64_decode(self::b64url2b64($base64url));
     }
 

--- a/src/LaravelOpenIdConnect.php
+++ b/src/LaravelOpenIdConnect.php
@@ -9,6 +9,7 @@ use CreativeCrafts\LaravelOpenidConnect\Exceptions\OpenIDConnectClientException;
 use CreativeCrafts\LaravelOpenidConnect\Services\OpenIDConnectConfig;
 use CreativeCrafts\LaravelOpenidConnect\Services\OpenIDConnectManager;
 use Illuminate\Http\Client\ConnectionException;
+use Psr\SimpleCache\InvalidArgumentException;
 
 final class LaravelOpenIdConnect implements LaravelOpenIdConnectContract
 {
@@ -39,6 +40,7 @@ final class LaravelOpenIdConnect implements LaravelOpenIdConnectContract
     /**
      * @throws OpenIDConnectClientException
      * @throws ConnectionException
+     * @throws InvalidArgumentException
      */
     public function authenticate(): bool
     {

--- a/src/LaravelOpenIdConnectServiceProvider.php
+++ b/src/LaravelOpenIdConnectServiceProvider.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace CreativeCrafts\LaravelOpenidConnect;
 
+use CreativeCrafts\LaravelOpenidConnect\Contracts\TokenStorageContract;
+use CreativeCrafts\LaravelOpenidConnect\Storage\CacheTokenStorage;
+use CreativeCrafts\LaravelOpenidConnect\Storage\NullTokenStorage;
+use CreativeCrafts\LaravelOpenidConnect\Storage\SessionTokenStorage;
+use Illuminate\Contracts\Cache\Factory;
+use Illuminate\Support\Facades\Config;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -15,5 +21,36 @@ class LaravelOpenIdConnectServiceProvider extends PackageServiceProvider
         $package
             ->name('laravel-openid-connect')
             ->hasConfigFile();
+    }
+
+    /**
+     * Register package services and bindings after the package has been registered.
+     * This method binds the TokenStorageContract to the appropriate storage implementation
+     * based on the configuration settings. It supports three storage drivers: cache, session,
+     * and none (null storage). The binding is configured to resolve the correct storage
+     * implementation when the TokenStorageContract is requested from the service container.
+     *
+     * @return void
+     */
+    public function packageRegistered(): void
+    {
+        // Bind token storage according to configuration for consumers who resolve it directly
+        $this->app->bind(TokenStorageContract::class, function ($app) {
+            $driver = Config::string(key: 'openid-connect.storage', default: 'session');
+            $prefix = Config::string(key: 'openid-connect.session_key_prefix', default: 'openid_connect_');
+            if ($driver === 'cache') {
+                $store = Config::string(key: 'openid-connect.cache_store', default: '');
+                /** @var Factory $cacheFactory */
+                $cacheFactory = $app['cache'];
+                $repo = $store !== '' && $store !== '0' ? $cacheFactory->store($store) : $app['cache.store'];
+                $ttl = Config::integer(key: 'openid-connect.cache_ttl', default: 300);
+                return new CacheTokenStorage($repo, $prefix, $ttl);
+            }
+            if ($driver === 'none') {
+                return new NullTokenStorage();
+            }
+            // default to session
+            return new SessionTokenStorage($app['session'], $prefix);
+        });
     }
 }

--- a/src/Services/OpenIDConnectConfig.php
+++ b/src/Services/OpenIDConnectConfig.php
@@ -112,9 +112,9 @@ final class OpenIDConnectConfig implements OpenIDConnectConfigContract
     /**
      * Retrieves the client ID for the OpenID Connect provider.
      *
-     * @return string|null The client ID or null if not set.
+     * @return string The client ID.
      */
-    public function getClientID(): ?string
+    public function getClientID(): string
     {
         return $this->clientID;
     }
@@ -132,9 +132,9 @@ final class OpenIDConnectConfig implements OpenIDConnectConfigContract
     /**
      * Retrieves the client secret for the OpenID Connect provider.
      *
-     * @return string|null The client secret or null if not set.
+     * @return string The client secret.
      */
-    public function getClientSecret(): ?string
+    public function getClientSecret(): string
     {
         return $this->clientSecret;
     }
@@ -239,9 +239,6 @@ final class OpenIDConnectConfig implements OpenIDConnectConfigContract
      */
     public function setScope(array $scope): void
     {
-        if (! is_array($scope)) {
-            throw new OpenIDConnectClientException('The scope must be an array');
-        }
         $this->scopes = array_merge($this->scopes, $scope);
     }
 

--- a/src/Services/OpenIDConnectJWTProcessor.php
+++ b/src/Services/OpenIDConnectJWTProcessor.php
@@ -239,7 +239,9 @@ final class OpenIDConnectJWTProcessor implements OpenIDConnectJWTProcessorContra
         }
 
         if (isset($currentHeader['kid'])) {
-            throw new OpenIDConnectClientException('Unable to find a key for (algorithm, kid):' . $currentHeader['alg'] . ', ' . $currentHeader['kid'] . ')');
+            $alg = isset($currentHeader['alg']) && is_string($currentHeader['alg']) ? $currentHeader['alg'] : '';
+            $kid = is_string($currentHeader['kid']) ? $currentHeader['kid'] : '';
+            throw new OpenIDConnectClientException('Unable to find a key for (algorithm, kid):' . $alg . ', ' . $kid . ')');
         }
 
         throw new OpenIDConnectClientException('Unable to find a key for RSA');

--- a/src/Services/OpenIDConnectTokenManager.php
+++ b/src/Services/OpenIDConnectTokenManager.php
@@ -13,7 +13,6 @@ use Exception;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Cache\Factory;
 use Illuminate\Contracts\Container\BindingResolutionException;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Config;
 use JsonException;
 use Psr\SimpleCache\InvalidArgumentException;
@@ -387,7 +386,7 @@ final class OpenIDConnectTokenManager implements OpenIDConnectTokenManagerContra
             return null;
         }
         return [
-            'nonce' => Arr::string(array: $data, key: 'nonce', default: ''),
+            'nonce' => fluent($data)->string(key: 'nonce')->value(),
             'code_verifier' => array_key_exists('code_verifier', $data) && $data['code_verifier'] !== null ? (string)$data['code_verifier'] : null,
         ];
     }

--- a/src/Services/OpenIDConnectTokenManager.php
+++ b/src/Services/OpenIDConnectTokenManager.php
@@ -5,11 +5,24 @@ declare(strict_types=1);
 namespace CreativeCrafts\LaravelOpenidConnect\Services;
 
 use CreativeCrafts\LaravelOpenidConnect\Contracts\OpenIDConnectTokenManagerContract;
-use CreativeCrafts\LaravelOpenidConnect\Exceptions\OpenIDConnectClientException;
+use CreativeCrafts\LaravelOpenidConnect\Contracts\TokenStorageContract;
+use CreativeCrafts\LaravelOpenidConnect\Storage\CacheTokenStorage;
+use CreativeCrafts\LaravelOpenidConnect\Storage\NullTokenStorage;
+use CreativeCrafts\LaravelOpenidConnect\Storage\SessionTokenStorage;
 use Exception;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Cache\Factory;
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Config;
+use JsonException;
+use Psr\SimpleCache\InvalidArgumentException;
 
 final class OpenIDConnectTokenManager implements OpenIDConnectTokenManagerContract
 {
+    private const STATE_BUNDLE_PREFIX = 'oidc:state:';
+    private TokenStorageContract $storage;
+
     // @pest-mutate-ignore
     private ?string $accessToken = null;
 
@@ -21,6 +34,59 @@ final class OpenIDConnectTokenManager implements OpenIDConnectTokenManagerContra
 
     // @pest-mutate-ignore
     private ?array $tokenResponse = null;
+
+    /**
+     * Initialises the OpenID Connect Token Manager with the specified storage implementation.
+     * This constructor sets up the token storage mechanism for the OpenID Connect session management.
+     * If no storage is provided, it automatically resolves the storage type from Laravel configuration
+     * or falls back to sensible defaults. Supported storage types include cache, session, and null (stateless).
+     *
+     * @param TokenStorageContract|null $storage Optional token storage implementation. If null, the storage
+     *                                          will be automatically resolved from Laravel configuration.
+     *                                          Defaults to session storage if Laravel is available,
+     *                                          otherwise falls back to null storage (stateless).
+     * @throws BindingResolutionException If there's an issue resolving dependencies from the Laravel container.
+     */
+    public function __construct(?TokenStorageContract $storage = null)
+    {
+        if ($storage instanceof TokenStorageContract) {
+            $this->storage = $storage;
+            return;
+        }
+
+        // Resolve storage from Laravel config if available, else default to stateless (null storage)
+        $storageRaw = function_exists('config') ? Config::string(key: 'openid-connect.storage') : null;
+        $storageDriver = is_string($storageRaw) ? $storageRaw : 'session';
+        $prefixRaw = function_exists('config') ? Config::string(key: 'openid-connect.session_key_prefix') : null;
+        $prefix = is_string($prefixRaw) ? $prefixRaw : 'openid_connect_';
+
+        if ($storageDriver === 'cache') {
+            $instance = class_exists(Container::class) ? Container::getInstance() : null;
+            if ($instance instanceof Container) {
+                /** @var Factory $cacheFactory */
+                $cacheFactory = $instance->make('cache');
+                $storeNameRaw = function_exists('config') ? Config::string(key: 'openid-connect.cache_store') : null;
+                $storeName = is_string($storeNameRaw) ? $storeNameRaw : null;
+                $cacheRepo = $storeName !== null && $storeName !== '' && $storeName !== '0' ? $cacheFactory->store($storeName) : $instance->make('cache.store');
+                $rawTtl = function_exists('config') ? Config::integer(key: 'openid-connect.cache_ttl', default: 300) : null;
+                $ttl = is_int($rawTtl) ? $rawTtl : null;
+                $this->storage = new CacheTokenStorage($cacheRepo, $prefix, $ttl);
+                return;
+            }
+        }
+
+        if ($storageDriver === 'session') {
+            $instance = class_exists(Container::class) ? Container::getInstance() : null;
+            if ($instance instanceof Container && $instance->bound('session')) {
+                $session = $instance->make('session');
+                $this->storage = new SessionTokenStorage($session, $prefix);
+                return;
+            }
+        }
+
+        // Fallback to null storage (stateless)
+        $this->storage = new NullTokenStorage();
+    }
 
     /**
      * Sets the access token for the OpenID Connect session.
@@ -47,7 +113,6 @@ final class OpenIDConnectTokenManager implements OpenIDConnectTokenManagerContra
      *
      * @param string|null $refreshToken The refresh token to be set. If null, the refresh token will be cleared.
      *
-     * @throws Exception If the random_bytes function fails to generate the required number of bytes for the refresh token.
      */
     public function setRefreshToken(?string $refreshToken): void
     {
@@ -68,7 +133,6 @@ final class OpenIDConnectTokenManager implements OpenIDConnectTokenManagerContra
      * Sets the ID token for the OpenID Connect session.
      *
      * @param string $idToken The ID token to be set. This token is used to authenticate the user and provide user information.
-     * @throws OpenIDConnectClientException
      */
     public function setIdToken(string $idToken): void
     {
@@ -120,8 +184,7 @@ final class OpenIDConnectTokenManager implements OpenIDConnectTokenManagerContra
      */
     public function commitSession(): void
     {
-        $this->startSession();
-        session_write_close();
+        $this->storage->commit();
     }
 
     /**
@@ -135,27 +198,22 @@ final class OpenIDConnectTokenManager implements OpenIDConnectTokenManagerContra
      */
     public function setSessionKey(string $key, string $value): void
     {
-        $this->startSession();
-        $_SESSION[$key] = $value;
+        $this->storage->put($key, $value);
     }
 
     /**
      * Retrieves a session key-value pair.
-     *
      * This method retrieves a value from the PHP session using the provided key.
      * If the key exists and its value is not empty, the method returns the value.
      * Otherwise, it returns null.
      *
      * @param string $key The key to be used for retrieving the value from the session.
      * @return string|null The value associated with the given key in the session, or null if the key does not exist or its value is empty.
+     * @throws InvalidArgumentException
      */
     public function getSessionKey(string $key): ?string
     {
-        $this->startSession();
-        if (array_key_exists($key, $_SESSION) && ! empty($_SESSION[$key])) {
-            return $_SESSION[$key];
-        }
-        return null;
+        return $this->storage->get($key);
     }
 
     /**
@@ -168,8 +226,7 @@ final class OpenIDConnectTokenManager implements OpenIDConnectTokenManagerContra
      */
     public function unsetSessionKey(string $key): void
     {
-        $this->startSession();
-        unset($_SESSION[$key]);
+        $this->storage->forget($key);
     }
 
     /**
@@ -182,20 +239,20 @@ final class OpenIDConnectTokenManager implements OpenIDConnectTokenManagerContra
      */
     public function setNonce(string $nonce): void
     {
-        $this->setSessionKey('openid_connect_nonce', $nonce);
+        $this->setSessionKey('nonce', $nonce);
     }
 
     /**
      * Retrieves the nonce value for the OpenID Connect session.
-     *
-     * The nonce is a random string that is used to prevent replay attacks. It is generated by the
+     * The nonce is a random string used to prevent replay attacks. It is generated by the
      * `generateRandString` method and stored in the PHP session.
      *
      * @return string|null The nonce value stored in the session, or null if it is not set.
+     * @throws InvalidArgumentException
      */
     public function getNonce(): ?string
     {
-        return $this->getSessionKey('openid_connect_nonce');
+        return $this->getSessionKey('nonce');
     }
 
     /**
@@ -207,7 +264,7 @@ final class OpenIDConnectTokenManager implements OpenIDConnectTokenManagerContra
      */
     public function unsetNonce(): void
     {
-        $this->unsetSessionKey('openid_connect_nonce');
+        $this->unsetSessionKey('nonce');
     }
 
     /**
@@ -220,20 +277,20 @@ final class OpenIDConnectTokenManager implements OpenIDConnectTokenManagerContra
      */
     public function setState(string $state): void
     {
-        $this->setSessionKey('openid_connect_state', $state);
+        $this->setSessionKey('state', $state);
     }
 
     /**
      * Retrieves the state value for the OpenID Connect session.
-     *
      * The state value is used to maintain the state between the client and the server during the authorization process.
      * It is generated by the `generateRandString` method and stored in the PHP session.
      *
      * @return string|null The state value stored in the session, or null if it is not set.
+     * @throws InvalidArgumentException
      */
     public function getState(): ?string
     {
-        return $this->getSessionKey('openid_connect_state');
+        return $this->getSessionKey('state');
     }
 
     /**
@@ -245,7 +302,7 @@ final class OpenIDConnectTokenManager implements OpenIDConnectTokenManagerContra
      */
     public function unsetState(): void
     {
-        $this->unsetSessionKey('openid_connect_state');
+        $this->unsetSessionKey('state');
     }
 
     /**
@@ -258,20 +315,20 @@ final class OpenIDConnectTokenManager implements OpenIDConnectTokenManagerContra
      */
     public function setCodeVerifier(string $codeVerifier): void
     {
-        $this->setSessionKey('openid_connect_code_verifier', $codeVerifier);
+        $this->setSessionKey('code_verifier', $codeVerifier);
     }
 
     /**
      * Retrieves the code verifier for the OpenID Connect session.
-     *
      * The code verifier is a random string used in the authorization code flow to prevent CSRF attacks.
      * It is generated by the `generateRandString` method and stored in the PHP session.
      *
      * @return string|null The code verifier stored in the session, or null if it is not set.
+     * @throws InvalidArgumentException
      */
     public function getCodeVerifier(): ?string
     {
-        return $this->getSessionKey('openid_connect_code_verifier');
+        return $this->getSessionKey('code_verifier');
     }
 
     /**
@@ -283,11 +340,12 @@ final class OpenIDConnectTokenManager implements OpenIDConnectTokenManagerContra
      */
     public function unsetCodeVerifier(): void
     {
-        $this->unsetSessionKey('openid_connect_code_verifier');
+        $this->unsetSessionKey('code_verifier');
     }
 
     /**
-     * Generates a random string of 32 characters using the bin2hex function and random_bytes function.
+     * Generates a random string of 32 characters using the bin hex function and random_bytes function.
+     *
      * @param int<1, max> $randomNumber The number of random bytes to generate. Default is 16.
      * @return string A random string of 32 characters.
      * @throws Exception If the random_bytes function fails to generate the required number of bytes.
@@ -297,10 +355,48 @@ final class OpenIDConnectTokenManager implements OpenIDConnectTokenManagerContra
         return bin2hex(random_bytes($randomNumber));
     }
 
-    protected function startSession(): void
+    /**
+     * Save a transient bundle scoped by state containing nonce and optional code_verifier.
+     *
+     * @throws JsonException
+     */
+    public function saveStateBundle(string $state, string $nonce, ?string $codeVerifier = null): void
     {
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
+        $payload = json_encode([
+            'nonce' => $nonce,
+            'code_verifier' => $codeVerifier,
+        ], JSON_THROW_ON_ERROR);
+        $this->storage->put(self::STATE_BUNDLE_PREFIX . $state, $payload);
+    }
+
+    /**
+     * Load a state-scoped transient bundle (nonce, code_verifier).
+     *
+     * @return array|null :?string}|null
+     * @throws InvalidArgumentException
+     * @throws JsonException
+     */
+    public function loadStateBundle(string $state): ?array
+    {
+        $raw = $this->storage->get(self::STATE_BUNDLE_PREFIX . $state);
+        if (!is_string($raw)) {
+            return null;
         }
+        $data = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        if (!is_array($data) || !isset($data['nonce'])) {
+            return null;
+        }
+        return [
+            'nonce' => Arr::string(array: $data, key: 'nonce', default: ''),
+            'code_verifier' => array_key_exists('code_verifier', $data) && $data['code_verifier'] !== null ? (string)$data['code_verifier'] : null,
+        ];
+    }
+
+    /**
+     * Clear the state-scoped bundle after it has been used.
+     */
+    public function clearStateBundle(string $state): void
+    {
+        $this->storage->forget(self::STATE_BUNDLE_PREFIX . $state);
     }
 }

--- a/src/Storage/CacheTokenStorage.php
+++ b/src/Storage/CacheTokenStorage.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CreativeCrafts\LaravelOpenidConnect\Storage;
+
+use CreativeCrafts\LaravelOpenidConnect\Contracts\TokenStorageContract;
+use DateInterval;
+use DateTimeInterface;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Psr\SimpleCache\InvalidArgumentException;
+
+final readonly class CacheTokenStorage implements TokenStorageContract
+{
+    public function __construct(
+        private CacheRepository $cache,
+        private string $prefix = 'openid_connect_',
+        private DateInterval|DateTimeInterface|int|null $ttl = null
+    ) {
+    }
+
+    /**
+     * Store a token value in the cache with the specified key.
+     *
+     * The key will be prefixed with the configured prefix to avoid cache key conflicts.
+     * If no TTL is configured, the value will be stored permanently using the cache's
+     * forever method. Otherwise, the value will be stored with the configured TTL.
+     *
+     * @param string $key The cache key identifier for the token
+     * @param string $value The token value to store in the cache
+     */
+    public function put(string $key, string $value): void
+    {
+        $cacheKey = $this->prefix . $key;
+        if ($this->ttl === null) {
+            $this->cache->forever($cacheKey, $value);
+            return;
+        }
+        $this->cache->put($cacheKey, $value, $this->ttl);
+    }
+
+    /**
+     * Retrieve a token value from the cache using the specified key.
+     * The key will be prefixed with the configured prefix to match the storage pattern.
+     * The method handles type safety by ensuring only string values are returned, with
+     * automatic casting for scalar values and null return for non-scalar or missing values.
+     *
+     * @param string $key The cache key identifier for the token to retrieve
+     * @return string|null The stored token value as a string, or null if not found or invalid type
+     * @throws InvalidArgumentException
+     */
+    public function get(string $key): ?string
+    {
+        $value = $this->cache->get($this->prefix . $key);
+        if (is_string($value)) {
+            return $value;
+        }
+        if ($value === null) {
+            return null;
+        }
+        if (is_scalar($value)) {
+            return (string) $value;
+        }
+        return null;
+    }
+
+    /**
+     * Remove a token from the cache using the specified key.
+     *
+     * The key will be prefixed with the configured prefix to match the storage pattern
+     * used by the put and get methods. This ensures consistent key handling across
+     * all cache operations.
+     *
+     * @param string $key The cache key identifier for the token to remove
+     */
+    public function forget(string $key): void
+    {
+        $this->cache->forget($this->prefix . $key);
+    }
+
+    /**
+     * Commit any pending changes to the storage backend.
+     *
+     * This method provides a consistent interface for storage implementations
+     * that may require explicit commit operations (such as database transactions).
+     * For cache-based storage, this is a no-operation as cache writes are
+     * immediately persisted when put() is called.
+     */
+    public function commit(): void
+    {
+        // No-op for cache
+    }
+}

--- a/src/Storage/NullTokenStorage.php
+++ b/src/Storage/NullTokenStorage.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CreativeCrafts\LaravelOpenidConnect\Storage;
+
+use CreativeCrafts\LaravelOpenidConnect\Contracts\TokenStorageContract;
+
+final class NullTokenStorage implements TokenStorageContract
+{
+    /**
+     * Store a token value with the specified key.
+     *
+     * This is a no-operation implementation that does not actually store anything.
+     * Used when token storage is disabled or not required.
+     *
+     * @param string $key The unique identifier for the token
+     * @param string $value The token value to store
+     */
+    public function put(string $key, string $value): void
+    {
+        // no-op
+    }
+
+    /**
+     * Retrieve a token value by its key.
+     *
+     * This is a no-operation implementation that always returns null,
+     * as this storage implementation does not actually store any tokens.
+     *
+     * @param string $key The unique identifier for the token to retrieve
+     * @return string|null Always returns null since no tokens are stored
+     */
+    public function get(string $key): ?string
+    {
+        return null;
+    }
+
+    /**
+     * Remove a token from storage by its key.
+     *
+     * This is a no-operation implementation that does not actually remove anything,
+     * as this storage implementation does not store any tokens to begin with.
+     *
+     * @param string $key The unique identifier for the token to remove
+     */
+    public function forget(string $key): void
+    {
+        // no-op
+    }
+
+    /**
+     * Commit any pending changes to the storage.
+     *
+     * This is a no-operation implementation that does not perform any commit operations,
+     * as this storage implementation does not actually store or modify any data.
+     */
+    public function commit(): void
+    {
+        // no-op
+    }
+}

--- a/src/Storage/SessionTokenStorage.php
+++ b/src/Storage/SessionTokenStorage.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CreativeCrafts\LaravelOpenidConnect\Storage;
+
+use CreativeCrafts\LaravelOpenidConnect\Contracts\TokenStorageContract;
+use Illuminate\Contracts\Session\Session as SessionContract;
+use InvalidArgumentException;
+
+final class SessionTokenStorage implements TokenStorageContract
+{
+    private SessionContract $session;
+    private string $prefix;
+
+    public function __construct(
+        object $session,
+        string $prefix = 'openid_connect_'
+    ) {
+        // Normalise: if a SessionManager/Factory is provided, get the underlying driver/store
+        if (method_exists($session, 'driver')) {
+            $driver = $session->driver();
+            if ($driver instanceof SessionContract) {
+                $session = $driver;
+            }
+        }
+
+        if (!$session instanceof SessionContract) {
+            throw new InvalidArgumentException('Session must implement ' . SessionContract::class);
+        }
+
+        $this->session = $session;
+        $this->prefix = $prefix;
+    }
+
+    /**
+     * Store a value in the session with the configured prefix.
+     *
+     * @param string $key The key to store the value under (will be prefixed)
+     * @param string $value The value to store in the session
+     */
+    public function put(string $key, string $value): void
+    {
+        $this->session->put($this->prefix . $key, $value);
+    }
+
+    /**
+     * Retrieve a value from the session using the configured prefix.
+     *
+     * This method fetches a value from the session storage using the provided key
+     * with the configured prefix prepended. It handles type conversion to ensure
+     * a string return value, converting scalar values to strings when possible.
+     *
+     * @param string $key The key to retrieve the value for (will be prefixed)
+     * @return string|null The stored value as a string, or null if not found or not convertible
+     */
+    public function get(string $key): ?string
+    {
+        $value = $this->session->get($this->prefix . $key);
+        if (is_string($value)) {
+            return $value;
+        }
+        if ($value === null) {
+            return null;
+        }
+        if (is_scalar($value)) {
+            return (string) $value;
+        }
+        return null;
+    }
+
+    /**
+     * Remove a value from the session using the configured prefix.
+     *
+     * This method removes a stored value from the session storage by deleting
+     * the entry associated with the provided key (with the configured prefix
+     * prepended). Once forgotten, the value will no longer be retrievable.
+     *
+     * @param string $key The key to remove from the session (will be prefixed)
+     */
+    public function forget(string $key): void
+    {
+        $this->session->forget($this->prefix . $key);
+    }
+
+    /**
+     * Commit and persist all session changes to storage.
+     *
+     * This method ensures that any pending session data modifications are
+     * written to the underlying storage mechanism. It checks if the session
+     * implementation supports the save() method and calls it to persist
+     * the current session state.
+     */
+    public function commit(): void
+    {
+        // Ensure the session is saved if supported
+        // @phpstan-ignore-next-line Laravel session contracts have save()
+        if (method_exists($this->session, 'save')) {
+            $this->session->save();
+        }
+    }
+}

--- a/tests/Helpers/Base64HelperTest.php
+++ b/tests/Helpers/Base64HelperTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use CreativeCrafts\LaravelOpenidConnect\Helpers\Base64Helper;
+
+it('encodes and decodes base64url correctly', function () {
+    $data = random_bytes(32);
+
+    $encoded = Base64Helper::b64urlEncode($data);
+
+    expect($encoded)
+        ->not()->toContain('=')
+        ->and($encoded)->toMatch('/^[A-Za-z0-9\-_]+$/');
+
+    $decoded = Base64Helper::base64urlDecode($encoded);
+    expect($decoded)->toBe($data);
+});
+
+it('converts base64url to standard base64 with correct padding restoration', function () {
+    $standard = base64_encode('foo'); // Zm9v
+    $url = rtrim(strtr($standard, '+/', '-_'), '=');
+
+    $converted = Base64Helper::b64url2b64($url);
+
+    expect($converted)->toBe($standard);
+});

--- a/tests/Services/OpenIDConnectManagerClaimsTest.php
+++ b/tests/Services/OpenIDConnectManagerClaimsTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+use CreativeCrafts\LaravelOpenidConnect\Services\OpenIDConnectHttpClient;
+use CreativeCrafts\LaravelOpenidConnect\Services\OpenIDConnectManager;
+use Illuminate\Support\Facades\Http;
+
+function makeManagerForClaims(): OpenIDConnectManager
+{
+    $config = [
+        'provider_url' => 'https://provider.example.com',
+        'client_id' => 'client-123',
+        'client_secret' => 'secret-xyz',
+        'redirect_url' => 'https://app.example.com/callback',
+        'scopes' => ['openid', 'profile'],
+        'jwks_uri' => 'https://provider.example.com/jwks',
+    ];
+
+    $manager = new OpenIDConnectManager($config);
+
+    // Set wellKnownConfig directly to avoid network calls
+    $refConfig = new ReflectionClass(getPrivateProperty($manager, 'config'));
+    $prop = $refConfig->getProperty('wellKnownConfig');
+    $prop->setAccessible(true);
+    $prop->setValue(getPrivateProperty($manager, 'config'), [
+        'issuer' => 'https://issuer.example.com',
+    ]);
+
+    return $manager;
+}
+
+it('gets JWKS via GET without calling well-known', function () {
+    $manager = makeManagerForClaims();
+
+    Http::fake([
+        'https://provider.example.com/jwks' => Http::response([
+            'keys' => [
+                ['kty' => 'RSA', 'kid' => '1', 'e' => 'AQAB', 'n' => 'AQAB'],
+            ],
+        ], 200, ['Content-Type' => 'application/json']),
+    ]);
+
+    $manager->setHttpClient(new OpenIDConnectHttpClient());
+
+    $ref = new ReflectionClass($manager);
+    $m = $ref->getMethod('getJwks');
+    $m->setAccessible(true);
+
+    $keys = $m->invoke($manager);
+    expect($keys)->toBeArray()->and($keys)->toHaveCount(1)->and($keys[0]['kid'])->toBe('1');
+});
+
+it('verifies JWT claims successfully (issuer, audience, sub, exp/nbf, nonce, at_hash)', function () {
+    $manager = makeManagerForClaims();
+
+    // Prepare TokenManager state: nonce and id_token (to infer alg RS256)
+    $refManager = new ReflectionClass($manager);
+    $tmProp = $refManager->getProperty('tokenManager');
+    $tmProp->setAccessible(true);
+    $tokenManager = $tmProp->getValue($manager);
+    $tokenManager->setNonce('abc123');
+
+    // Minimal header with alg RS256 to influence at_hash computation length
+    $header = base64_encode(json_encode(['alg' => 'RS256'], JSON_THROW_ON_ERROR));
+    $payload = base64_encode(json_encode(['sub' => 'user'], JSON_THROW_ON_ERROR));
+    $tokenManager->setIdToken($header . '.' . $payload . '.sig');
+
+    $accessToken = 'access_token_value';
+
+    // Compute expected at_hash per validateAccessTokenHash logic
+    $hash = hash('sha256', $accessToken, true);
+    $half = substr($hash, 0, 16);
+    $expectedAtHash = (new ReflectionClass($manager))->getProperty('jwtProcessor');
+    $expectedAtHash->setAccessible(true);
+    /** @var CreativeCrafts\LaravelOpenidConnect\Services\OpenIDConnectJWTProcessor $jwt */
+    $jwt = $expectedAtHash->getValue($manager);
+    $atHash = $jwt->urlEncode($half);
+
+    // Build claims object
+    $now = time();
+    $claims = (object) [
+        'iss' => 'https://issuer.example.com',
+        'aud' => ['client-123'],
+        'sub' => 'user-1',
+        'exp' => $now + 300,
+        'nbf' => $now - 10,
+        'nonce' => 'abc123',
+        'at_hash' => $atHash,
+    ];
+
+    $method = $refManager->getMethod('verifyJWTClaims');
+    $method->setAccessible(true);
+
+    $ok = $method->invoke($manager, $claims, $accessToken);
+    expect($ok)->toBeTrue();
+});
+
+it('fails JWT claims verification when audience does not include client_id', function () {
+    $manager = makeManagerForClaims();
+
+    $refManager = new ReflectionClass($manager);
+    $method = $refManager->getMethod('verifyJWTClaims');
+    $method->setAccessible(true);
+
+    $claims = (object) [
+        'iss' => 'https://issuer.example.com',
+        'aud' => ['some-other-client'],
+        'sub' => 'user-1',
+    ];
+
+    $ok = $method->invoke($manager, $claims, 'token');
+    expect($ok)->toBeFalse();
+});

--- a/tests/Services/OpenIDConnectTokenManagerStateBundleTest.php
+++ b/tests/Services/OpenIDConnectTokenManagerStateBundleTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use CreativeCrafts\LaravelOpenidConnect\Services\OpenIDConnectTokenManager;
+
+beforeEach(function () {
+    $this->tm = new OpenIDConnectTokenManager();
+});
+
+it('saves and loads a state bundle with nonce and code_verifier', function () {
+    $state = 'state_' . bin2hex(random_bytes(4));
+    $nonce = 'nonce_' . bin2hex(random_bytes(4));
+    $codeVerifier = 'cv_' . bin2hex(random_bytes(4));
+
+    $this->tm->saveStateBundle($state, $nonce, $codeVerifier);
+
+    $bundle = $this->tm->loadStateBundle($state);
+
+    expect($bundle)
+        ->toBeArray()
+        ->and($bundle['nonce'])->toBe($nonce)
+        ->and($bundle['code_verifier'])->toBe($codeVerifier);
+});
+
+it('saves and loads a state bundle without code_verifier', function () {
+    $state = 'state_' . bin2hex(random_bytes(4));
+    $nonce = 'nonce_' . bin2hex(random_bytes(4));
+
+    $this->tm->saveStateBundle($state, $nonce, null);
+
+    $bundle = $this->tm->loadStateBundle($state);
+
+    expect($bundle)
+        ->toBeArray()
+        ->and($bundle['nonce'])->toBe($nonce)
+        ->and($bundle['code_verifier'])->toBeNull();
+});
+
+it('returns null when loading a non-existent state bundle', function () {
+    $missing = $this->tm->loadStateBundle('does_not_exist_' . bin2hex(random_bytes(4)));
+    expect($missing)->toBeNull();
+});
+
+it('clears a saved state bundle', function () {
+    $state = 'state_' . bin2hex(random_bytes(4));
+    $nonce = 'nonce_' . bin2hex(random_bytes(4));
+
+    $this->tm->saveStateBundle($state, $nonce, null);
+    expect($this->tm->loadStateBundle($state))->not()->toBeNull();
+
+    $this->tm->clearStateBundle($state);
+    expect($this->tm->loadStateBundle($state))->toBeNull();
+});


### PR DESCRIPTION
Introduce TokenStorageContract with session, cache (TTL-supported), and stateless (none) implementations, and bind it via the service container based on configuration. Refactor TokenManager to use the storage abstraction and add state-bundled persistence of nonce/code_verifier keyed by state. Harden state/nonce handling and improve PKCE and JWT/JWKS processing.

Added
- TokenStorageContract and drivers: SessionTokenStorage, CacheTokenStorage, NullTokenStorage
- Container binding for TokenStorageContract (configured via openid-connect.php)
- Config options: openid-connect.storage, session_key_prefix, cache_store, cache_ttl
- State bundle save/load/clear to support reliable state validation across flows
- Tests: Base64Helper; OpenIDConnectManager JWT claims; TokenManager state bundle

Changed
- TokenManager now delegates storage and commitSession to the selected storage backend
- Authorization Code + Implicit flows load nonce/code_verifier from state bundle, and clear secrets after use
- PKCE: correct challenge/method handling; always clear code_verifier after token request attempt
- Response type derived from config; improved input validation and exceptions
- JSON decoding now uses JSON_THROW_ON_ERROR; safer header handling in JWTProcessor
- Base64Helper::base64urlDecode returns string (not bool|string)
- OpenIDConnectConfig::getClientID/getClientSecret return non-nullable string

Security
- More robust state/nonce management and cleanup; clearer failure modes

BREAKING CHANGE
- Session key names are normalised (nonce/state/code_verifier) and managed through a pluggable storage layer
- getClientID/getClientSecret are now non-nullable
- Base64Helper::base64urlDecode signature now returns string